### PR TITLE
encoding compatible and default output filename

### DIFF
--- a/ipynb_py_convert/__main__.py
+++ b/ipynb_py_convert/__main__.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from os import path
+import io
 
 header_comment = '# %%\n'
 
@@ -70,22 +71,52 @@ def py2nb(py_str):
     return notebook
 
 
+def get_encoding(path):
+    encodings = ['utf-8', 'utf-16', 'utf-32', 'utf-7', 'utf-16-be', 'utf-16-le',
+                 'ascii', 'euc-kr', 'euc-jp', 'euc-jis-2004', 'euc-jisx0213', 'gb2312', 'gbk', 'hz', 'latin-1',
+                 'koi8-r', 'koi8-u', 'mac-cyrillic', 'mac-greek', 'mac-iceland', 'mac-latin2', 'mac-roman',
+                 'mac-turkish', 'ptcp154', 'shift-jis', 'shift-jis-2004', 'shift-jisx0213',
+                 'cp437', 'cp949', 'cp932',
+                 'windows-1250', 'windows-1252', ]
+    for enc in encodings:
+        try:
+            f = io.open(path, 'r', encoding=enc)
+            f.readlines()
+            f.seek(0)
+        except FileNotFoundError as ex:
+            return 'utf-8'
+        except Exception as ex:
+            pass
+        else:
+            return enc
+    return 'unknown'
+
+
+def open_autoenc(path, mode, encoding=''):
+    if len(encoding)==0:
+        enc = get_encoding(path)
+    else:
+        enc = encoding
+#     print(enc)
+    return open(path, mode, encoding=enc)
+
+
 def convert(in_file, out_file):
     _, in_ext = path.splitext(in_file)
     _, out_ext = path.splitext(out_file)
 
     if in_ext == '.ipynb' and out_ext == '.py':
-        with open(in_file, 'r') as f:
+        with open_autoenc(in_file, 'r') as f:
             notebook = json.load(f)
         py_str = nb2py(notebook)
-        with open(out_file, 'w') as f:
+        with open_autoenc(out_file, 'w') as f:
             f.write(py_str)
 
     elif in_ext == '.py' and out_ext == '.ipynb':
-        with open(in_file, 'r') as f:
+        with open_autoenc(in_file, 'r') as f:
             py_str = f.read()
         notebook = py2nb(py_str)
-        with open(out_file, 'w') as f:
+        with open_autoenc(out_file, 'w') as f:
             json.dump(notebook, f, indent=2)
 
     else:
@@ -94,12 +125,25 @@ def convert(in_file, out_file):
 
 def main():
     argv = sys.argv
-    if len(argv) < 3:
-        print('Usage: ipynb-py-convert in.ipynb out.py')
-        print('or:    ipynb-py-convert in.py out.ipynb')
+    out_file = ''
+    if len(argv) < 2:
+        print('Usage: ipynb-py-convert in.ipynb [out.py]')
+        print('or:    ipynb-py-convert in.py [out.ipynb]')
         sys.exit(1)
 
-    convert(in_file=argv[1], out_file=argv[2])
+    if len(argv) == 2:
+        out_file = argv[1]
+        exts = out_file.split('.')
+        filename = '.'.join(exts[:-1])
+        if exts[-1] == 'ipynb':
+            out_file = filename+'.py'
+        if exts[-1] == 'py':
+            out_file = filename+'.ipynb'
+
+    else:
+        out_file = argv[2]
+
+    convert(in_file=argv[1], out_file=out_file)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with io.open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='ipynb-py-convert',
     packages=['ipynb_py_convert'],
-    version='0.4.4',
+    version='0.4.5',
     description='Convert .py files runnable in VSCode/Python or Atom/Hydrogen to jupyter .ipynb notebooks and vice versa',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION

1. Convert failed in Windows OS of certain languages. 
![image](https://user-images.githubusercontent.com/6326475/65978950-839c9e80-e4af-11e9-8f2a-bd28b20b1390.png)

I updated the file open method to automatically check the encoding type.

2. default output file name (same as input file name)
  no need to specify output file name

