### PR TITLE
qoute sign changed

### DIFF
--- a/ipynb_py_convert/__main__.py
+++ b/ipynb_py_convert/__main__.py
@@ -13,7 +13,7 @@ def nb2py(notebook):
         cell_type = cell['cell_type']
 
         if cell_type == 'markdown':
-            result.append("%s'''\n%s\n'''" %
+            result.append('%s"""\n%s\n"""'%
                           (header_comment, ''.join(cell['source'])))
 
         if cell_type == 'code':
@@ -34,6 +34,9 @@ def py2nb(py_str):
         cell_type = 'code'
         if chunk.startswith("'''"):
             chunk = chunk.strip("'\n")
+            cell_type = 'markdown'
+        elif chunk.startswith('"""'):
+            chunk = chunk.strip('"\n')
             cell_type = 'markdown'
 
         cell = {


### PR DESCRIPTION
The formatting tool black (strongly) favors """ over '''.  When my file is saved, it is auto-formatted by black. The first time I used ipynb-py-convert I was a bit surprised that the change from ''' to """ broke ipynb-py-convert, and it took me some time to figure out that this was the problem.  Of course, it is easy to pass an option to black to leave the quotes untouched (which I did), but perhaps it is better to change this somewhat odd (in my opinion) of ipynb-py-convert to only accept ''' in comments.